### PR TITLE
[gnome-extra/evolution-tray] corrected dependency

### DIFF
--- a/gnome-extra/evolution-tray/evolution-tray-0.0.8.ebuild
+++ b/gnome-extra/evolution-tray/evolution-tray-0.0.8.ebuild
@@ -13,5 +13,5 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-DEPEND="mail-client/evolution"
+DEPEND="<=mail-client/evolution-3.0.0"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
The ebuild fails with

```
No package 'evolution-plugin-3.0' found
```

(see full error [here](https://bpaste.net/show/60d4bb657033)).
